### PR TITLE
make dst_filename optional

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,10 +15,10 @@ see [INSTALL](INSTALL)
 
 ## USAGE
 
-    mucrop <src_filename> <dst_filename>
+    mucrop <src_filename> [dst_filename]
 
 ### KEYBINDINGS
 
-*   w: writes the cropped image to <dst_filename>
+*   w: writes the cropped image to <dst_filename> if given, otherwise rewrites <src_filename>
 *   q: quits without writing
 * ESC: cancels the current crop operation

--- a/mucrop.c
+++ b/mucrop.c
@@ -291,7 +291,7 @@ static void handle_x11_error(struct mucrop_core *core)
 
 static void usage(bool err)
 {
-	fputs("usage: mucrop <src_filename> <dst_filename>\n", err ? stderr : stdout);
+	fputs("usage: mucrop <src_filename> [dst_filename]\n", err ? stderr : stdout);
 }
 
 int main(int argc, const char *argv[])
@@ -303,9 +303,12 @@ int main(int argc, const char *argv[])
 	struct timespec tp;
 	int ret = 0;
 
-	if (argc != 3) {
+	if (argc != 2 && argc != 3) {
 		usage(true);
 		return EX_USAGE;
+	}
+	if (argc == 2) {
+		dst_filename = src_filename;
 	}
 
 	MagickWandGenesis();

--- a/mucrop.c
+++ b/mucrop.c
@@ -299,16 +299,20 @@ int main(int argc, const char *argv[])
 	struct mucrop_core core = {};
 	xcb_generic_event_t *ev;
 	const char *src_filename = argv[1];
-	const char *dst_filename = argv[2];
+	const char *dst_filename;
 	struct timespec tp;
 	int ret = 0;
 
-	if (argc != 2 && argc != 3) {
-		usage(true);
-		return EX_USAGE;
-	}
-	if (argc == 2) {
-		dst_filename = src_filename;
+	switch (argc) {
+		case 2:
+			dst_filename = src_filename;
+			break;
+		case 3:
+			dst_filename = argv[2];
+			break;
+		default:
+			usage(true);
+			return EX_USAGE;
 	}
 
 	MagickWandGenesis();


### PR DESCRIPTION
mucrop had to be called with both a src_filename and dst_filename, if
the user wanted to replace the src with the cropped image, he had to
supply the filename twice.

By making the dst_filename optional, cropping-and-replacing a file is
made slightly easier.